### PR TITLE
regra de batalha: proteção do núcleo

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -6,4 +6,4 @@
 * Não é permitido atirar com o escudo ativado.
 * Ambas as naves devem iniciar com a luz branca da paz (LBP) acesas.
 * Se piscar a LBP três vezes, é fim de batalha, com vitória para o adversário.
-
+* Phaser não pode ser apontado para o núcleo de força da nave.


### PR DESCRIPTION
Regra para proteger o sistema de manutenção da vida nas naves.