### PR TITLE
Regra sobre criptografias: Proibidas

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -8,4 +8,4 @@
 * Se piscar a LBP três vezes, é fim de batalha, com vitória para o adversário.
 * Antes de iniciar a batalha, cumprimente o oponente usando o R2D2 para transmitir 3 beeps.
 * O ataque com ondas giratórias vale 4 pontos
-
+* Não é permitido o uso de criptografias, uma vez que sempre estarão fadadas a serem quebradas só resultam em perda de tempo em uma Spacewar.


### PR DESCRIPTION
" Não é permitido o uso de criptografias, uma vez que sempre estarão fadadas a serem quebradas só resultam em perda de tempo em uma Spacewar." Minha proposta de regra para a contribuição na regulamentação das guerras, por acreditar fielmente na inutilidade das criptografias devido a evolução dos sistemas de redes neurais e computação quântica que conseguem identificar os padrões e quebrar-las mais rapidamente do que demoraram para serem elaboradas.