### PR TITLE
Regra Relâmpago da força 

### DIFF
--- a/MERGE_MSG
+++ b/MERGE_MSG
@@ -1,0 +1,9 @@
+Merge branch 'develop' into release
+
+# Please enter a commit message to explain why this merge is necessary,
+# especially if it merges an updated upstream into a topic branch.
+#
+# Lines starting with '#' will be ignored, and an empty message aborts
+# the commit 
+nova regra será criada
+.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -43,9 +43,11 @@
 41. Se voce encontrar o sabre de luz de Luke Skyewalker voce passara a dar dano duplicado.
 42. Quando destruir uma nave inimiga reportar a seus superiores.
 43. Caixas de Pandora não podem ser usadas quando o horário presente tem números primos.
-<<<<<<< HEAD
+
 44. Atire em todos Pokemons que avistar.
 45. Os escudos de energia da nave não poderão aguentar mais que 4 torpedos de íons
-=======
-    Baú contendo um relâmpago da força será distribuido para o vencedor para ser ultilizado no próximo jogo contra o Darth Vader.   
->>>>>> release
+ 
+ 
+ 
+ Baú contendo um relâmpago da força será distribuido para o vencedor para ser ultilizado no próximo jogo contra o Darth Vader.   
+


### PR DESCRIPTION
Nova regra para o spacewar: O vencedor da partida terá direito a um relâmpago da força como recompensa para o próximo jogo. 