### PR TITLE
Regra 73, imortalidade

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -72,3 +72,4 @@
 70. Ataques usando a Força geram Danos tripicados.
 71. Caso o Spok apareça, fuja.
 72. Cavalos de oito patas e coelhos de quatro podem tentar lhe enganar quando der meia noite.
+73. Ao encontrar a camisa do Sport, use-a e se tornará imortal.


### PR DESCRIPTION
Adicionada a regra 73 ao Spacewar onde a tal afirma: "Ao encontrar a camisa do Sport, use-a e se tornará imortal". 



