### PR TITLE
regra 76 adicionada

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -75,3 +75,4 @@
 73. Ao encontrar a camisa do Sport, use-a e se tornará imortal.
 74. Imediatamente antes do amanhecer, os vampiros espaciais deverão se esconder da luz UV.
 75. Ao capturar um Mimikyu, descarte todos os seus Pikachus.
+76. A regra de número 100 só será aceita caso cite mestre Yoda.


### PR DESCRIPTION
Regra 76 adicionada:  regra sobre citação posterior do mestre Yoda.