### PR TITLE
Regra 77: Respiração

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -76,3 +76,4 @@
 74. Imediatamente antes do amanhecer, os vampiros espaciais deverão se esconder da luz UV.
 75. Ao capturar um Mimikyu, descarte todos os seus Pikachus.
 76. Comer cuscuz com ovo lhe dá sustância e revigora suas energias.
+77. Comer uma Ruffles prolonga o tempo em que voce pode prender a respiracao no espaco por 10 minutos.


### PR DESCRIPTION
Adicionada regra 77, que fala dos efeitos da ingestão de Ruffles nas capacidades pulmonares das unidades.