### PR TITLE
Regra Adicionada (80): Regra sobre pergaminho jiraya

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -79,3 +79,4 @@
 77. Comer uma Ruffles prolonga o tempo em que voce pode prender a respiracao no espaco por 10 minutos.
 78. A regra de número 100 só será aceita mediante citação do Mestre Yoda.
 79. Colete 5 escudos e ganhe 30 segundos de invisibilidade.
+80. Caso encontre o pergaminho do jiraya você ganha a oportunidade de invocar o gamabunta.


### PR DESCRIPTION
# **Pull Request**

_Regra 80 da a opção ao jogador de invocar o grande sapo Gamabunta, mas para isso tem que estar de posse do pergaminho jiraya._

