### PR TITLE
Regra 81: Dória chanceler

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -73,3 +73,4 @@
 71. Caso o Spok apareça, fuja.
 72. Cavalos de oito patas e coelhos de quatro podem tentar lhe enganar quando der meia noite.
 73. Ao encontrar a camisa do Sport, use-a e se tornará imortal.
+74. Se rolar menos de dez, a república será invadida pelos Yuuzhan Vong.


### PR DESCRIPTION
Regra 81, se trata sobre o prefeito da cidade de São Paulo se tornar um chanceler intergalático e prender o Lula amanhã.