### PR TITLE
Regra 86: Regra das Chuvas de Castamere

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -74,4 +74,5 @@
 72. Cavalos de oito patas e coelhos de quatro podem tentar lhe enganar quando der meia noite.
 73. Ao encontrar a camisa do Sport, use-a e se tornará imortal.
 74. Imediatamente antes do amanhecer, os vampiros espaciais deverão se esconder da luz UV.
-75. Ao capturar um Mimikyu, descarte todos os seus Pikachus.
+75. Ao capturar um Mimikyu, descarte todos os seus Pikachus
+76. Caso esteja sendo observado pelo olho de Sauron, não utilizar o 'UM' anel e, quando possível, aproveitar um breve pedaço de lembas.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -81,3 +81,4 @@
 79. Colete 5 escudos e ganhe 30 segundos de invisibilidade.
 80. Caso o inimigo se transforme em gigante, voce podera chamar um Mega Zord.
 81. Caso seu X-bacon caia durante a batalha, o akernaak esta proibido de gritar birrrl.
+82. Ao parar no porto espacial de Mos Eisley, relaxe ouvindo o tema da Cantina enquanto aproveita um Kamikaze.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -77,3 +77,4 @@
 75. Ao capturar um Mimikyu, descarte todos os seus Pikachus.
 76. Comer cuscuz com ovo lhe dá sustância e revigora suas energias.
 77. Comer uma Ruffles prolonga o tempo em que voce pode prender a respiracao no espaco por 10 minutos.
+78. In i gilith, ennas na- bau thenid. Er ceri- ú- simplui palad- na i gilith.


### PR DESCRIPTION
# Regra 86

    * Adicionada a regra 86, que diz: "Se houver algum Stark em naves próximas, exalte o canto das Chuvas de Castamere."