### PR TITLE
Regra 87 : Transações intergaláticas

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -77,3 +77,4 @@
 75. Ao capturar um Mimikyu, descarte todos os seus Pikachus.
 76. Comer cuscuz com ovo lhe dá sustância e revigora suas energias.
 77. Comer uma Ruffles prolonga o tempo em que voce pode prender a respiracao no espaco por 10 minutos.
+78. Em trasações intergaláticas usar o cone do silencio para mais segurança.


### PR DESCRIPTION
Adicionada a regra 87, que diz: "Em caso de transações intergalaticas,usar o cone do silencio por medida de precaução."