### PR TITLE
Regra de batalha 90:  Capacete especial 100RR

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -89,3 +89,4 @@
 87. Em caso de transações intergalaticas,usar o cone do silencio por medida de precaução.
 88. Cada teletubbie do planeta Jeremias 13 libera uma quest específica.
 89. A cada alien morto você ganhará uma torta .
+90. Ao sobrevoar um cinturao de saturno, use o capacete especial 100RR.


### PR DESCRIPTION
# Solicitação de adição da Regra 90

# Regra de batalha 90:  Capacete especial 100RR

 * "Ao sobrevoar um cinturao de saturno, use o capacete especial 100RR."

