### PR TITLE
Regra 90 dos magos inserida

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -89,3 +89,4 @@
 87. Em caso de transações intergalaticas,usar o cone do silencio por medida de precaução.
 88. Cada teletubbie do planeta Jeremias 13 libera uma quest específica.
 89. A cada alien morto você ganhará uma torta .
+90. Numa guerra espacial, os magos não devem consumir vinho.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -70,3 +70,4 @@
 68. A nave que acertar o Titio Avô vence a batalha.
 69. Quando a câmara secreta for aberta, todos os mestiços devem se esconder.
 70. Ataques usando a Força geram Danos tripicados.
+71. Se chegou até aqui, dê três pulos.


### PR DESCRIPTION
regra 90 "Numa guerra espacial, os magos não devem consumir vinho."