### PR TITLE
regra 95 adicionada

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -93,4 +93,5 @@
 91. Caso o Senhor Madruga seja visto, toda a frota estelar estará devendo 1000 Dracmas ao Senhor Barriga.
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
-94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
+94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas
+95. Nunca deve destruir um universo sem antes de conquista-lo.


### PR DESCRIPTION
A regra 95 foi adicionada devido ao fato de dificultar mais a regra dentre os demais citados. A propósito da minha regra foi o dificultamento da destruição do universo sem antes de entede-la e adquiri-la.
