### PR TITLE
Regra de Batalha 95 : Destrua o Voldemort

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,4 +94,4 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
-95. Destrua o Voldemort com o feitiço verdimilliouns e ganhe 20 pontos de experiência.
+95. Destrua o Voldemort com o feitiço "verdimilliouns" e ganhe 20 pontos de experiência.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,3 +94,4 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
+95. Destrua o Voldemort com o feitiço verdimilliouns e ganhe 20 pontos de experiência.


### PR DESCRIPTION

Regra de batalha 95 sobre destruir o Voldemort com o feitiço "verdimillions" e ganhar 20 pontos de experiênica.