### PR TITLE
Regra 95: uso da velocidade da luz

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,3 +94,5 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
+95. Viagem em velocidade da luz só é permitida após destruir 3 naves inimigas.
+

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,5 +94,5 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
-95. Viagem em velocidade da luz só é permitida após destruir 3 naves inimigas.
+95. O uso da velocidade da luz só é permitida após destruir 3 naves inimigas.
 


### PR DESCRIPTION
- Regra 95: a partir desta regra, o jogador só poderá utilizar a velocidade da luz após destruir 3 naves inimigas.
