### PR TITLE
Regra 95: Carregamento de Duendes

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -88,4 +88,5 @@
 86. Se houver algum Stark em naves próximas, exalte o canto das Chuvas de Castamere
 87. Em caso de transações intergalaticas,usar o cone do silencio por medida de precaução.
 88. Cada teletubbie do planeta Jeremias 13 libera uma quest específica.
-89. A cada alien morto você ganhará uma torta .
+89. A cada alien morto você ganhará uma torta.
+90. Viajar em velocidades que excedem 2x a velocidade de dobra causa 50% de chance de criação de anomalias no espaço-tempo.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -90,4 +90,4 @@
 88. Cada teletubbie do planeta Jeremias 13 libera uma quest específica.
 89. A cada alien morto você ganhará uma torta .
 90. Ao sobrevoar um cinturao de saturno, use o capacete especial 100RR
-91. Viajar em velocidades que excedem 2x a velocidade de dobra causa 50% de chance de criação de anomalias no espaço-tempo.
+91. Viajar em velocidades que excedem 2x a velocidade de dobra causa 50% de chance de criação de anomalias no espaçotempo.


### PR DESCRIPTION
Adição da Regra 95 ao Spacewar.

Regra 95: Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.