### PR TITLE
Nova Regra: Sabre de Luz

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,3 +94,4 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
+95. Ao ficar com menos de 10% de durabilidade a sua nave pode ativar o modo de Autodestruição, recomeçando a batalha caso seu adversário não esquive.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,4 +94,4 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
-95. Ao ficar com menos de 10% de durabilidade a sua nave pode ativar o modo de Autodestruição, recomeçando a batalha caso seu adversário não esquive.
+95. Ignore a regra 78 caso possua um sabre de luz verde.


### PR DESCRIPTION
O Usuário deve ignorar a regra de numero 78 caso possua um sabre de luz da cor verde.