### PR TITLE
Regra 98: Benefício ao achar minérios valiosos em planetas

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -96,3 +96,4 @@
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
+97. Encontrar um novo planeta com minérios valiosos vai aumentar seu placar no duelo final.


### PR DESCRIPTION
Adição da regra 98.
Quando forem achados minérios valiosos em um planeta seu placar aumentará.