### PR TITLE
Regra 98: Tire uma selfie com Darth Vader

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -97,3 +97,4 @@
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
 97. O piloto que der uma volta inteira na galáxia Andromeda em menos de 12 parsecs ganha um escudo que reverte o próximo ataque contra quem o atacou.
+98. Tirar uma selfie com Darth Vader lhe trará para o lado escuro da força!


### PR DESCRIPTION
Adição da regra 98.
Tirar uma fotografia com o Lord Vader lhe mostrará o lado escuro da força!