### PR TITLE
Regra de batalha 99: Morte do capitão.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,3 +94,4 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
+95. Construa uma USS Enterprise

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -96,3 +96,4 @@
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
+97. Caso o capitão morra, vote no yopresidente.


### PR DESCRIPTION
Regra de batalha adicionada referente à morte do capitão da nave.