### PR TITLE
Regra 99: O cálice de fogo.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -93,4 +93,5 @@
 91. Caso o Senhor Madruga seja visto, toda a frota estelar estará devendo 1000 Dracmas ao Senhor Barriga.
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
-94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
+94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas
+95. Quem encontrar o livro ,The Progamming, terá o poder de controlar a mente de 5 androids inimigos.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -97,3 +97,4 @@
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
 97. O piloto que der uma volta inteira na galáxia Andromeda em menos de 12 parsecs ganha um escudo que reverte o próximo ataque contra quem o atacou.
+98. Quem encontrar a chuteira espacial ganhara um contrato no psg.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -97,4 +97,3 @@
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
 97. O piloto que der uma volta inteira na galáxia Andromeda em menos de 12 parsecs ganha um escudo que reverte o próximo ataque contra quem o atacou.
-98. Quem encontrar a chuteira espacial ganhara um contrato no psg.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -96,3 +96,4 @@
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
+97. atualizar

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -96,4 +96,4 @@
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
-97. atualizar
+97. atualiza  r

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -96,4 +96,3 @@
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
-97. Quem encontrar o pinguim espacial perdido tem o poder de quebrar a janela de uma nave inimiga.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -94,8 +94,6 @@
 92. Derrote um inimigo e receba um Diamante Negro que lhe fornecerá uma Super Força, isto lhe tornará invencível.
 93. Numa luta contra uma nave duas vezes maior, seu ataque será duas vezes mais forte. 
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas
-95. Quem encontrar o livro ,The Progamming, terá o poder de controlar a mente de 5 androids inimigos.
-94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
-97. Quem achar o pinguin espacial perdido tem a chance de quebrar a janela da nave inimiga.
+97. Quem encontrar o pinguim espacial perdido tem o poder de quebrar a janela de uma nave inimiga.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -98,3 +98,4 @@
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
 97. O piloto que der uma volta inteira na galáxia Andromeda em menos de 12 parsecs ganha um escudo que reverte o próximo ataque contra quem o atacou.
 98. Se o celular do piloto descarregar, o jogador perde pontos.
+99. O primeiro que conseguir matar o dragao ganha a oportunidade de colocar o nome no calice de fogo.


### PR DESCRIPTION
Essa regra permite que o jogador coloque seu nome dentro do cálice de fogo.