### PR TITLE
Regra 99: morte predefinida

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -96,3 +96,4 @@
 94. Os pilotos só devem sair de suas naves após finalizar todas as batalhas.
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
+97. O humano cujo nome for escrito nas regras morrerá logo após o início da partida.


### PR DESCRIPTION
Regra 98: morte definida pelas regras da partida.