### PR TITLE
Regra 101 Lei de transito aeroespacial

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -97,3 +97,4 @@
 95. Quem conseguir a armadura do Homem de Ferro, fica isento de qualquer ataque por 10 segundos.
 96. Carregar duendes no compartimento de cargas aumenta sua chance de encontrar planetas com minérios valiosos.
 97. O piloto que der uma volta inteira na galáxia Andromeda em menos de 12 parsecs ganha um escudo que reverte o próximo ataque contra quem o atacou.
+98. Faça 10 flexoes e ganhe super força por 1 minuto.


### PR DESCRIPTION
Regra 101:
Está feita a primeira e única lei de transito aeroespacial, que informa a todos os pilotos que não devem cometer nenhuma infração, pois estarão sujeitos a pena.