### PR TITLE
Adicionada regra 101 sobre o ganho de imunidade se estiver na nave 

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -100,3 +100,4 @@
 98. Se o celular do piloto descarregar, o jogador perde pontos.
 99. Caso o capitão da nave morra, vote no Yopresidente.
 100. O uso da velocidade da luz só permitida após a apresentacao do selo da Guarda Intergalatica.
+101. Pessoas a bordo da Uss Enterprise ganham imunidade até a próxima rodada.


### PR DESCRIPTION
Adicionei a regra que faz com que as pessoas que estão a bordo da Uss Enterprise ganham imunidade até a próxima rodada