### PR TITLE
Regra 109 sobre uso do QuinJet adicionada

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -108,3 +108,4 @@
 106. Travis test 6 -- drbeco forked
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
+109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.


### PR DESCRIPTION
Arquivo spacewar-rules.md alterado. Foi adicionada uma nova regra, a próxima da lista ( nº 109 ), referente ao uso do QuinJet.