### PR TITLE
Regra 112:a dependencia do nautico

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -109,3 +109,4 @@
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+voce so poderá respirar no espaço se o nautico for campeao de alguma coisa.


### PR DESCRIPTION
descrição:Regra que diz que o jogador só poderá respirar no espaço caso o nautico seja campeão de alguma coisa.