### PR TITLE
Regra 110: o jogador que não decolar com a nave, vai a pé

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -109,3 +109,4 @@
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+110. Se a nave não decolcar, vá a pé


### PR DESCRIPTION
Regra diz que se a nave não decolar, o jogador vai a pé