### PR TITLE
Regra 110: O ataque da Pokebola

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -108,4 +108,5 @@
 106. Travis test 6 -- drbeco forked
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
-109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD
+110. Caso o jogador fique mais de 10 minutos inativo, uma pokebola o sequestra.


### PR DESCRIPTION
Descrição: Uma pokebola sequestra o jogador inativo. 