### PR TITLE
regra 101 adicionada: ultra capa de invisibilidade

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -100,7 +100,7 @@
 98. Se o celular do piloto descarregar, o jogador perde pontos.
 99. Caso o capitão da nave morra, vote no Yopresidente.
 100. O uso da velocidade da luz só permitida após a apresentacao do selo da Guarda Intergalatica.
-101. Travis test
+101. O vencedor da corrida mortal terá direito a usar a ultra capa de invisibilidade durante 3 horas de batalha. 
 102. Travis test 2
 103. Travis test 3
 104. Travis test 4 -- drbeco forked


### PR DESCRIPTION
Descrição: regra que afirma que após a corrida mortal, o competidor que conseguir chegar primeiro terá direito de usar a ultra capa de invisibilidade por 3 horas de batalha.

Regra: o vencedor da corrida mortal, terá direito de usar a ultra capa de invisibilidade durante 3 horas de batalha.

