### PR TITLE
regra 110: Corra de Jiren.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -109,3 +109,4 @@
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+110. Caso Jiren aparecer e voce nao for Goku, corra.


### PR DESCRIPTION
Jiren é muito forte, só Goku pode derrotá-lo.
Jiren treinou por muito tempo, e adquiriu uma quantidade de poder de 1.000.000 de ki, caso você não seja Goku, fuja dele o mais rápido possível.

