### PR TITLE
Regra 111: Aparicao do Capitao America 

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -109,3 +109,5 @@
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+
+111. Caso o Capitão América apareça, o jogador ganhará pontos.


### PR DESCRIPTION
A seguinte regra informa ao jogador que se o herói Capitão América aparecer, o jogador irá ganhar pontos.


