### PR TITLE
regra 113 adicionada: ataque zumbi

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -111,3 +111,4 @@
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
 110. Se a nave não decolcar, vá a pé
 111. Caso o Capitão América aparecer, o jogador ganhará pontos. 
+112. Se o zumbi morder um jogador, este último deverá tomar a porção da cura.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -112,4 +112,4 @@
 110. Se a nave não decolcar, vá a pé
 111. Caso o Capitão América aparecer, o jogador ganhará pontos. 
 112. Se comecar a chuver meteoros, abra o guarda chuva.
-113. Se o zumbi morder voce, tome a porção de cura.
+113. Se o zumbi morder voce, tome a poção de cura.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -112,3 +112,4 @@
 110. Se a nave não decolcar, vá a pé
 111. Caso o Capitão América aparecer, o jogador ganhará pontos. 
 112. Se comecar a chuver meteoros, abra o guarda chuva.
+113. Se o zumbi morder voce, tome a porção de cura.


### PR DESCRIPTION
regra que diz que o jogador que for atacado por um zumbi devera tomar a porção da cura.