### PR TITLE
regra 113: regra da capivara

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -112,3 +112,4 @@
 110. Se a nave não decolcar, vá a pé
 111. Caso o Capitão América aparecer, o jogador ganhará pontos. 
 112. Se comecar a chuver meteoros, abra o guarda chuva.
+113. O jogador não pode guardar uma capivara no porta-luvas da sua nave.


### PR DESCRIPTION
Essa regra proíbe o jogador de guardar uma capivara no porta-luvas da sua nave.