### PR TITLE
regra 113: não é permitido sonhar

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -109,3 +109,4 @@
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+110. Quando anoitecer, vá dormir antes das 19:00, ou morrerah.


### PR DESCRIPTION
regra113: sonhar é para os fracos, nossa legião não permite sonhos.