### PR TITLE
regra 117: Hiperespaço

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -114,3 +114,4 @@
 112. Se comecar a chuver meteoros, abra o guarda chuva.
 113. Se o zumbi morder voce, tome a poção de cura.
 114. Caso o Doutor Estranho apareça, você pode pular uma fase do jogo.
+115. Se voce somar mais de 100 pontos ganhe a mulher maravilha como companheira durante os proximos 2 desafios.


### PR DESCRIPTION
a regra diz que se caso você não tenha feito pontos na rodada anterior, o jogador perde a habilidade de entrar no hiperespaço por uma rodada