### PR TITLE
Regra 118: Ligando para o Scooby-Doo

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -116,3 +116,4 @@
 114. Caso o Doutor Estranho apareça, você pode pular uma fase do jogo.
 115. Se o homem aranha aparecer, bata continencia.
 116. Caso freeza apareca, jogue uma genki dama nele.
+117. Ao chegar no nível 17 do jogo, você pode usar o ataque kumehameha.


### PR DESCRIPTION
Essa regra consiste que só quando chegar no nível 21 do jogo, você poderá ligar para o Scooby-Doo.