### PR TITLE
Regra 121: Cavaleiro de ouro

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -118,3 +118,4 @@
 116. Caso freeza apareca, jogue uma genki dama nele.
 117. Caso voce não tenha feito pontos na rodada anterior, perca a habilidade de entrar no hiperespaco por uma rodada.
 118. Só poderá ser feita a ligação para o Scooby-Doo, ao atingir o nível 21.
+119. Ao ver o Luke Skywalker, chame-o para lutar junto com você na batalha final.


### PR DESCRIPTION
Essa regra diz que o jogador ao chegar na casa de touros do cavaleiro de ouro, ele ganhará mais 115 de XP.