### PR TITLE
Regra 123: Escudo Defletor

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -120,4 +120,4 @@
 118. Só poderá ser feita a ligação para o Scooby-Doo, ao atingir o nível 21.
 119. Se estiver a bordo do teco-teco 3000, você está imune a pedágios espaciais
 120. Caso você entre no labirinto de Dédalo, você ficará preso em 10 rodadas
-121. Caso aparecer um fauno, você fica é levado para Apokolips e fica fora até que seja solto
+121. Caso aparecer um fauno, você é levado para Apokolips e fica fora do jogo até que seja solto

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -113,4 +113,4 @@
 111. Caso o Capitão América aparecer, o jogador ganhará pontos. 
 112. Se comecar a chuver meteoros, abra o guarda chuva.
 113. Se o zumbi morder voce, tome a poção de cura.
-114. Se a policía federal pegar você vindo da china, seus itens ficam 3 meses em Curitiba se  os Correios não os extraviarem.
+e a policía federal pegar você vindo da china, seus itens ficam 3 meses em Curitiba se  os Correios não os extraviarem.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -113,3 +113,4 @@
 111. Caso o Capitão América aparecer, o jogador ganhará pontos. 
 112. Se comecar a chuver meteoros, abra o guarda chuva.
 113. Se o zumbi morder voce, tome a poção de cura.
+114. Se a policía federal pegar você vindo da china, seus itens ficam 3 meses em Curitiba se  os Correios não os extraviarem.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -115,3 +115,4 @@
 113. Se o zumbi morder voce, tome a poção de cura.
 114. Caso o Doutor Estranho apareça, você pode pular uma fase do jogo.
 115. Se o homem aranha aparecer, bata continencia
+116. Se o Thanos aparecer com a manopla do infinito, metade dos jogadores perde metade de suas vidas.


### PR DESCRIPTION
A regra diz que o piloto/jogador que não ligar o escudo defletor , leva 20% de dano a mais.