### PR TITLE
Regra 129 :  A saúde dos guerreiros

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -109,3 +109,4 @@
 107. Travis test 7 -- drbeco forked
 108. Travis test 8 -- drbeco forked
 109. O uso do QuinJet só deverá ser utilizado mediante autorização prévia do diretor da SHIELD.
+110. Um Vogon acabou de atacar voce. Nao entre em panico. Va para a sua nave e chore ou lute ate a morte.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -126,4 +126,4 @@
 124. Se você não ligar o propulsor espacial,o Império lhe fará prisioneiro.
 125. Ao avistar os marcianos, use a arma supersônica.
 126. Caso tenha duvida de que inimigo atacar, leia o TODO.txt.
-127. Em caso de feriado, falte a batalha e deixe a luta pra depois.
+127. Em caso de feriado, falte a batalha e deixe a luta pra segunda feira.


### PR DESCRIPTION
A regra fala que no caso de algum combatente ferido, vá para a upa e fique 239 horas esperando.
