### PR TITLE
Regra 129:a toca do timbu.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -127,3 +127,4 @@
 125. Ao avistar os marcianos, use a arma supersônica.
 126. Caso tenha duvida de que inimigo atacar, leia o TODO.txt.
 127. Quando você está com fome, automaticamente aparecerá um drive-thru.
+128. Se o hangar explodir, várias armas aparecerão.


### PR DESCRIPTION
Nessa regra, o jogador é alertado a não entrar na toca do timbu espacial, pois há risco de morrer.