### PR TITLE
Regra 131: Regra da capivara

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -129,3 +129,4 @@
 127. Quando você está com fome, automaticamente aparecerá um drive-thru.
 128. No estágio das sombras o jogador poderá evocar a Metaltex e  a Bladeliner para enfrentar o terrível Goldar.
 129. No caso de algum combatente ferido, va para a upa e fique 239 horas esperando.
+130. O jogador não pode guardar uma capivara no porta-luvas da sua nave.


### PR DESCRIPTION
Essa regra proíbe o jogador de guardar um capivara no porta-luvas da sua nave.