### PR TITLE
 Regra 134: Fase bônus 

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,3 +133,5 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
+134. Quando você conseguir 100 pontos de lataria, Sua nave ganha um boost de energia que permite que você vá até uma fase bônus. 
+

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,5 +133,4 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
-134. Quando você conseguir 100 pontos de lataria, Sua nave ganha um boost de energia que permite que você vá até uma fase bônus. 
-
+134. Quando você conseguir 100 pontos de lataria, Sua nave ganha um boost de energia que permite que você vá até uma fase bônus.


### PR DESCRIPTION
Essa regra é para colocar um objetivo que gera como recompensa uma fase extra.