### PR TITLE
Regra 134: Regra do cachorro inteligente

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,3 +133,4 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
+134. Se voce encontrar um cachorro numa bicicleta de oculos, voce passa duas fases.


### PR DESCRIPTION
As chances de você encontrar um cachorro numa bicicleta de óculos são baixas, mesmo em níveis avançados. Por isso, caso você encontra-lo, será um bom proveito para avançar duas fases.