### PR TITLE
Regra 134: Futebol

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,3 +133,4 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
+135. Se voce conseguir andar com o cachorro solto no espaco, voce chegara na metade do jogo.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,4 +133,4 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
-134. Quando o Santa Cruz e o Nautico subir para serie A o jogo sera zerado.
+134. Quando o Santa Cruz for para serie A o jogo será zerado.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,4 +133,4 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
-134. Quando o Santa Cruz for para serie A o jogo será zerado.
+134. Quando o Brasil for hexa o jogo sera zerado.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -133,4 +133,4 @@
 131. Se você entrar no buraco negro numero 32, encontrará o monstro do lago Nass.
 132. Caso você compre um Space Lanche Feliz na SpaceDonald's, você ganhará uma miniatura do do Chewbacca.
 133. Se a palavra Whyegdhhwclnvnpvei for falada de tras para frente, o jogo termina.
-135. Se voce conseguir andar com o cachorro solto no espaco, voce chegara na metade do jogo.
+134. Quando o Santa Cruz e o Nautico subir para serie A o jogo sera zerado.


### PR DESCRIPTION
Essa regra serve para o jogador ficar ciente que o jogo só será zerado quando o Brasil for hexa.