### PR TITLE
Regra 138: Ataque pelas costas

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -136,3 +136,4 @@
 134. Se seus amigos mafiarem com você , escolha o número deles da chamada
 135. Se o Galactus destruir a sua nave, volte para a dimensão gama.
 136. Snipers em Marte são permitidos.
+137. Se o inimigo estiver de costas o dano será multiplicado por quatro.


### PR DESCRIPTION
A regra 138 amplia o mecanismo de batalha do spacewar. Se o inimigo for atacado pelas costas o dano será multiplicado por quatro.

