### PR TITLE
 Regra de batalha 140: regra da zona vermelha

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -140,3 +140,4 @@
 138. Se o inimigo receber um ataque por trás, então o dano será multiplicado por quatro.
 139. Caso você tente conviver em sociedade e batalhar ao mesmo tempo, morrerá.
 140. Se vc tiver mais 5000 comandos na nave hydra, saia da zona vermelha.
+141. Atire em todos os digimons do mau, se forem vermelhos.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -139,3 +139,4 @@
 137. Se o Thanos aparecer com a manopla, segurem o Petter Quill.
 138. Se o inimigo receber um ataque por trás, então o dano será multiplicado por quatro.
 139. Caso você tente conviver em sociedade e batalhar ao mesmo tempo, morrerá.
+140. Se vc tiver mais 5000 comandos na nave hydra, saia da zona vermelha.


### PR DESCRIPTION
 Regra de batalha 140: regra da zona vermelha.Se o jogador tiver mais de 5000 comandos na nave Hydra, ele sai da zona vermelha.

