### PR TITLE
Regra 140: Han exclui Kirk!

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -139,3 +139,4 @@
 137. Se o Thanos aparecer com a manopla, segurem o Petter Quill.
 138. Se o inimigo receber um ataque por trás, então o dano será multiplicado por quatro.
 139. Caso você tente conviver em sociedade e batalhar ao mesmo tempo, morrerá.
+140. Se Han entrar no jogo, Kirk terá que sair.


### PR DESCRIPTION
Regra 140: Se Han entrar no jogo, Kirk terá que sair.