### PR TITLE
Regra 141: Buraco negro mágico

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -140,3 +140,4 @@
 138. Se o inimigo receber um ataque por trás, então o dano será multiplicado por quatro.
 139. Caso você tente conviver em sociedade e batalhar ao mesmo tempo, morrerá.
 140. Quando você conseguir 100 pontos de lataria, sua nave ganha um boost de energia que permite que você vá até uma fase bônus que possui o item monitoria louca.
+141. Se entrar no buraco negro delta, você será levado para o país das Maravilhas e encontrará o coelho branco que te dará ajuda.


### PR DESCRIPTION
O buraco negro delta irá te levar para uma dimensão louca no país das Maravilhas, onde você receberá uma ajuda extra na sua missão.