### PR TITLE
Regra 142: Cauda de macaco

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -141,3 +141,4 @@
 139. Caso você tente conviver em sociedade e batalhar ao mesmo tempo, morrerá.
 140. Quando você conseguir 100 pontos de lataria, sua nave ganha um boost de energia que permite que você vá até uma fase bônus que possui o item monitoria louca.
 141. Se entrar no buraco negro delta, você será levado para o país das Maravilhas e encontrará o coelho branco que te dará ajuda.
+142. Se cortar a cauda de macaco do Goku ele perde o poder.


### PR DESCRIPTION
Regra 142 aumenta o escopo de combate do jogo. Permite retirar o poder do Goku cortando a cauda de macaco dele.

