### PR TITLE
Regra 144: Harry Potter

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -143,3 +143,4 @@
 141. Se entrar no buraco negro delta, você será levado para o país das Maravilhas e encontrará o coelho branco que te dará ajuda.
 142. Woody pertence a Andy, não tente rouba-lo, pois criatividade vale mais.
 143. Se a cauda do charmander apagar então ele morre.
+144. Se Voldmort aparecer, chame Harry Potter.


### PR DESCRIPTION
Em função de toda história que envolve Harry e Voldemort, apenas o pequeno bruxo consegue deter Tom.