### PR TITLE
regra 146: Para realizar viagens interestelares

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -145,3 +145,4 @@
 143. Se a cauda do charmander apagar então ele morre.
 144. Se Voldmort aparecer, chame Harry Potter.
 145. Se a temperatura do motor passar de 1000K é necessário aguardar 3 rodadas.
+146. Para realizar viagens interestelares é necessário o kit Re piola light (Açaí + Batata doce).


### PR DESCRIPTION
Uso do kit de alimentação para viagens interestelares.

