### PR TITLE
Regra 153: termine o percurso de Kessel e ganhe pontos de maestria

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -152,3 +152,4 @@
 150. Quando estiver preocupado pule num pé só.
 151. Se precisar de ajuda chame a Hulkbuster.
 152. Ao comer o cogumelo colorido você irá ganhar +20 de XP.
+153. Ao terminar o Percurso de Kessel em até 12 Parsecs você ganha +20 pontos de maestria em pilotagem.


### PR DESCRIPTION
Regra 153: terminar o percurso de Kessel lhe dá pontos de maestria.