### PR TITLE
Regra 155: Arma dourada causa dobro de dano

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -153,3 +153,4 @@
 151. Se precisar de ajuda chame a Hulkbuster.
 152. Ao comer o cogumelo colorido você irá ganhar +20 de XP.
 153. Se o inimigo usa sabre de luz, ativar sabre de luz, senão, use arma laser.
+154. Ao pegar a arma dourada, cause o dobro de dano, porem, perca metade da vida.


### PR DESCRIPTION
A arma dourada causa o dobro de dano mas remove metade da vida do usuário. 