### PR TITLE
regra de batalha: aumentando escudo

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -162,3 +162,4 @@
 160. Caso encontre um Vulcano em sua jornada jogue uma partida de pedra, papel, tesoura, lagarto, Spock com ele.
 161. Para andar use as pernas.
 162. Para comer use a boca.
+163. Caso ganhe a partida contra um Vulcano, seu escudo ganha +150 de armadura


### PR DESCRIPTION
Regra 163: quando você ganhar a partida contra um Vulcano, a armadura do seu escudo é aumentada