### PR TITLE
regra de batalha: requisito para comer

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -162,3 +162,5 @@
 160. Caso encontre um Vulcano em sua jornada jogue uma partida de pedra, papel, tesoura, lagarto, Spock com ele.
 161. Para andar use as pernas.
 162. Para comer use a boca.
+163. Você só pode comer se possuir comida na bolsa.
+


### PR DESCRIPTION
A regra anterior diz como comer, mas para comer precisa do alimento.