### PR TITLE
regra de batalha: escolher arma para combater orcs

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -164,3 +164,4 @@
 162. Para comer use a boca.
 163. So durma quando acabar a batalha.
 164. Quando acordar é necessário trocar de roupa, caso contrário perderá o jogo.
+165. Ao trocar de roupa escolha sua arma para combater os orcs.


### PR DESCRIPTION
REGRA 165: Depois de trocar a roupa é necessário escolher uma arma para combater os orcs.