### PR TITLE
Regra de equipamento : ordem de direção ao campo de batalha

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -165,3 +165,4 @@
 163. So durma quando acabar a batalha.
 164. Quando acordar é necessário trocar de roupa, caso contrário perderá o jogo.
 165. Ao trocar de roupa escolha sua arma para combater os orcs.
+166. Após escolher sua arma, vá para o campo de batalha.


### PR DESCRIPTION
Para ir ao campo de batalha precisa ter a arma.




