### PR TITLE
regra da batalha: elfo escudeiro

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -175,3 +175,4 @@
 173. Para voar, se jogue.
 174. Caso ganhe uma partida contra um Vulcano, seu escudo ganha +150 de armadura.
 175. Caso voce encontre o Demogorgon, procure a Eleven.
+176. Se voce encontrar Valfenda, terá um elfo escudeiro pelo resto do jogo.


### PR DESCRIPTION
Regra 176: elfo escudeiro
    * se você encontrar valfenda, terá um elfo como escudeiro pelo resto do jogo 



