### PR TITLE
regra de batalha: dominio dos 4 elementos

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -175,3 +175,4 @@
 173. Para voar, se jogue.
 174. Caso ganhe uma partida contra um Vulcano, seu escudo ganha +150 de armadura.
 175. Caso voce encontre o Demogorgon, procure a Eleven.
+176. Domine os quatro elementos para ativar o modo Avatar.


### PR DESCRIPTION
Regra 176: Domine os quatro elementos para ativar o modo Avatar.