### PR TITLE
Regra da batalha: por segurança é necessário deitar e rolar ao ver um orc em uma distancia de 30 metros.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -176,3 +176,4 @@
 174. Caso ganhe uma partida contra um Vulcano, seu escudo ganha +150 de armadura.
 175. Caso voce encontre o Demogorgon, procure a Eleven.
 176. se voce achar o greedo voce ganha +15 de XP
+177. Se ver um orc no alcance de 30 metros deite e role para que ele não o veja.


### PR DESCRIPTION
Regra 177: Se ver um orc no alcance de 50 metros deite e role para que ele não o veja.

