### PR TITLE
Regra 179 - Tripulação

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -175,3 +175,4 @@
 173. Para voar, se jogue.
 174. Caso ganhe uma partida contra um Vulcano, seu escudo ganha +150 de armadura.
 175. Caso voce encontre o Demogorgon, procure a Eleven.
+176. Só aceite virar pirata se o capitão usar um chapéu de palha.

--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -178,3 +178,4 @@
 176. se voce achar o greedo voce ganha +15 de XP
 177. Domine os 4 elementos para ativar o modo Avatar.
 178. Se ver um orc no alcance de 30 metros deite e role para que ele não o veja.
+179. Só vire pirata se o Capitão usar um chapéu de palha.


### PR DESCRIPTION
Regra 179: Só vire pirata se o Capitão usar um chapéu de palha.