### PR TITLE
Regra de batalha: jogar xadrez contra o elfo perdido

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -162,3 +162,4 @@
 160. Caso encontre um Vulcano em sua jornada jogue uma partida de pedra, papel, tesoura, lagarto, Spock com ele.
 161. Para andar use as pernas.
 162. Para comer use a boca.
+163. Se encontrar o elfo perdido, jogue uma partida de xadrez contra ele.


### PR DESCRIPTION
Regra 179: Se encontrar o elfo perdido, jogue uma partida de xadrez contra ele.