### PR TITLE
Regra de batalha 199: Posto Ipiranga

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -198,3 +198,4 @@
 196. Use o comando diff para ter asas de dragao.
 197. Se o goku tiver dificuldades ele pinta o cabelo.
 198. Cada vez que voce alcançar 100 XP, ganhara escudo extra.
+199. Quando acabar a gasolina fale Ipiranga 3 vezes que um posto de reabastecimento aparece.


### PR DESCRIPTION
Durante a jornada, caso o nosso combustível acabe e fiquemos sem uma alternativa próxima, o jogador pode falar a palavra secreta 'Ipiranga" três vezes que ele e o seu veículo serão instantaneamente deslocados do local que se encontram para o Posto Ipiranga mas próximo.