### PR TITLE
regra 202: Cuidado com tomadas

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -201,3 +201,4 @@
 199. Quando acabar a gasolina fale Ipiranga 3 vezes que um posto de reabastecimento aparece.
 200. Quando o sol se por, aproveite para descansar na praia.
 201. Se mergulhar, não vôe de avião nas próximas 48h.
+202. Tenha cuidado com tomadas, você pode levar choques.


### PR DESCRIPTION
## Regra 202:

    -  Devido à alta voltagem das tomadas residenciais, caso você coloque o dedo em uma e tenha contato com o fio, você levará 
    um choque e pode morrer, tenha cuidado.



