### PR TITLE
Regra 220

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -214,4 +214,5 @@
 212. Nao coma cogumelos perto de canos.
 213. Ao capturar monstros use um bruxo.
 214. Caso encoste em uma estrela dourada, fique imune a todas as fraquezas por duas rodadas.
-215. Se estiver em perigo iminente sua energia espiritual é liberada.
+215. Se estiver em perigo iminente sua energia espiritual é liberada
+216. Caso encontre uma fogueira, descanse nela e recupere seu hp.


### PR DESCRIPTION
Regra 220: o sabre de luz so pode ser usado por quem tiver destreza +11
Descrição : O sabre requer um nivel de destreza alto para ser bem utilizado
