### PR TITLE
regra 289: Ame as pessoas que odeiam LoL, elas sabem de algo.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -288,3 +288,4 @@
 286. Olhe ao redor e tenha cuidado com o sapo rei.
 287. Se o X lhe chamar pra destruir a JAA, não aceite.
 288. Não conte seus segredos para Imu Sama ou ele ira fazer com você o mesmo que fez com o Rei Kobra.
+289. Ame as pessoas que odeiam LoL, elas sabem de algo.


### PR DESCRIPTION
# Regra 289: 
* Ame as pessoas que odeiam LoL, elas sabem de algo.
> Lol é um jogo muito chato (apesar de eu jogar ele a quase 10 anos, é melhor estudar e focar em algo, do que perder tempo jogando esse jogo inutil. a  conclusão que temos é que pessoas sensatas odeiam).