### PR TITLE
regra 292: Nao coma um tijolo

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -291,3 +291,4 @@
 289. Ame as pessoas que odeiam LoL, elas sabem de algo.
 290. Ache uma divisao para o Santa Cruz.
 291. Se ver o Mario grite MAMMAMIA e de uma voadora no Luigi.
+292. Nao coma um tijolo.


### PR DESCRIPTION
regra 292: "Nao coma um tijolo faz mal pra saude e provavelmente nao vai dar certo"

