### PR TITLE
313. Realizar manobra do tipo "cavalo-de-pau" com a nave gera +50XP.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -312,3 +312,4 @@
 310. Se ouvir a musica meio termo beba 4 doses de pitu.
 311. Se você ver o Pica-pau lutando com o Godzilla, viaje para a Camboja.
 312. No dia mais ensolarado beba uma cerveja nossa e faça um churrasco.
+313. Realizar manobra do tipo "cavalo-de-pau" com a nave gera +50XP.


### PR DESCRIPTION
Realizar a manobra "cavalo-de-pau" é algo a ser apoiado pois gera adrenalina e induz o jogador a se desafiar, preparando-o para agir em momentos de mais tensão.
