### PR TITLE
PM rejeitado: Motivo: Não usar acentos em mensagens de commit

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -314,5 +314,3 @@
 312. No dia mais ensolarado beba uma cerveja nossa e faça um churrasco.
 313. Realizar manobra do tipo "cavalo-de-pau" com a nave gera +50XP.
 314. Piratas viajaram e o aviao caiu.
-315. Coma cuscuz se quiser ser alguém na vida.
-


### PR DESCRIPTION
Reverts BecoSystems/spacewar#1015