### PR TITLE
regra 324: Nao coma manga com um buldog frances na copa.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -323,3 +323,4 @@
 321. Chute a bola com a perna direita.
 322. Jogue fps e ganhe 600 de xp.
 323. Nao se convertam ao machadado 98 hohohohoho
+324. Nao coma manga com um buldog frances na copa.


### PR DESCRIPTION
minha regra e sobre nao comer manga com um buldog frances na copa, voce nao conseguira cuidar do bicho enquanto ve o jogo ,por isso nao coma manga com um buldog frances na copa.