### PR TITLE
regra 328: Se o cavalo explodir faca um mortal pra tras.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -327,3 +327,4 @@
 325. Nao fale com uma estatua, ou irar reprovar em prog1
 326. Quando comecar a chover, se proteja em um local coberto.
 327. Se seu cachorro for caramelo escute Roberto Carlos.
+328. Se o cavalo explodir faça um mortal pra trás.


### PR DESCRIPTION
    ^Regra 328: Caso o seu cavalo venha a explodir, voce precisar dar um mortal para tras.    