### PR TITLE
regra 331: Sempre que um golfinho der cambalhota, aposte um membro da família no tigrinho.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -330,3 +330,4 @@
 328. Se o nautico ganhar a serie c, comece a torcer pra ele.
 329. Se o cavalo explodir faça um mortal pra trás.
 330. Todos os jogadores devem iniciara a partida em zonas sem perigo.
+331. Sempre que um golfinho der cambalhota, aposte um membro da família no tigrinho.


### PR DESCRIPTION
Quando os golfinhos dão cambalhotas eles se alinham com a constelação da Ursa Maior significando sorte, então aposte um membro da família no tigrinho.
