### PR TITLE
Regra 348: Caso viaje para Malaga, nao peca uma ambulancia as cinco.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -347,3 +347,4 @@
 345. Se passar por Triunfo dê 3 pulinhos.
 346. Nao pule no sol, porque e quente.
 347. Se escutar o canto das sereias vai ter que cantar com elas todas as musicas do filme Mamma Mia.
+348. Caso viaje para Malaga, nao peca uma ambulancia as cinco.


### PR DESCRIPTION
Em Málaga, na Espanha, existe um horário durante o dia em que as pessoas trancam seus comércios, lojas, para descansar e é durante as duas até as cinco da tarde, por isso pedir uma ambulância ás cinco não é o mais indicado.