### PR TITLE
regra 396: Se platinar silksong ganha um item para um final secreto.

### DIFF
--- a/spacewar-rules.md
+++ b/spacewar-rules.md
@@ -396,3 +396,4 @@
 393. Você só passa pela porta se entregar uma paçoca
 394. Peixe de chapeu azul resolveu cantar.
 395. Se encontrar um macaco, pule no pula-pula.
+396. Se platinar silksong ganha um item para um final secreto.


### PR DESCRIPTION
Se platinar silksong ganha um item para um final secreto.
Se não tiver moedas suficientes, não compra um item.

